### PR TITLE
Automate some pull request labels with Labeler

### DIFF
--- a/.github/actions/labeler.yml
+++ b/.github/actions/labeler.yml
@@ -1,0 +1,19 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,22 @@
+# Configuration for Labeler action workflow
+
+# Changes to the bot core.
+core:
+  - any: ["core/", "./rose.py"]
+
+# Changes to the dependency management files.
+dependencies:
+  - any: ["Pipfile*", "docs/requirements.txt"]
+
+# Changes to the documentation.
+documentation:
+  - any: ["docs/*"]
+    all: ["!docs/requirements.txt"]
+
+# Changes to an extension/cog module.
+extension module:
+  - any: ["module/*.py"]
+
+# Changes to Git and GitHub related files.
+repository:
+  - any: [".gitignore", ".gitattributes", ".github/*"]


### PR DESCRIPTION
Sets up the [Pull Request Labeler](https://github.com/actions/labeler) action to automatically label some pull requests, based on the files modified. I guess it's also a good example of making use of the actions system?

Here's a quick list of labels used and what files would trigger their application:
|Label|Paths|
|-|-|
|core|`core/`, `./rose.py`|
|dependencies|`Pipfile*`, `docs/requirements.txt`|
|documentation|`docs/*` (_except for `docs/requirements.txt`_)|
|extension module|`module/*.py`|
|repository|`.gitignore`, `.gitattributes`, `.github/*`|

**There is one caveat:** For security reasons, it only works with PRs pulling from the same repository. PRs pulling from branches on forks (like this one) won't be automatically labeled.

From the [readme for Labeler](https://github.com/actions/labeler/blob/main/README.md#pull-request-labeler) itself:
> Note that only pull requests being opened from the same repository can be labeled. This action will not currently work for pull requests from forks -- like is common in open source projects -- because the token for forked pull request workflows does not have write permissions.